### PR TITLE
Add: css 작성법 추가

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,10 @@
     transform: rotate(360deg);
   }
 }
+
+/* App.css파일에 box 스타일링을 해도 Hello.css 의 box 스타일이 적용됨 */
+.box {
+  width: 200px;
+  height: 100px;
+  background-color: black;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,14 @@
 import "./App.css";
 import Hello from "./components/Hello.js";
-import Welcome from "./components/Welcome.js";
+import styles from "./App.module.css";
+import "./App.css";
 
 function App() {
   return (
     <div className="App">
       <Hello />
-      <Hello />
-      <Welcome />
+      <div className={styles.box}>App-module</div>
+      <div className="box">App</div>
     </div>
   );
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,5 @@
+.box {
+  width: 100px;
+  height: 100px;
+  background-color: red;
+}

--- a/src/components/Hello.css
+++ b/src/components/Hello.css
@@ -1,0 +1,5 @@
+.box {
+  width: 200px;
+  height: 100px;
+  background-color: aqua;
+}

--- a/src/components/Hello.js
+++ b/src/components/Hello.js
@@ -1,11 +1,28 @@
-import World from "./World.js";
+import "./Hello.css";
+import styles from "./Hello.module.css";
 
 const Hello = () => {
   return (
     <div>
-      <p>Hello</p>
-      <World />
-      <World />
+      {/* 1. 인라인 스타일
+      - JSX 는 객체로 작성해야 된다.
+      - key: 속성, value: 속성값
+      - 객체이기 때문에 쉼표로 구분해준다.
+      - 대쉬를 사용했던 속성들은 카멜케이스로 작성한다.
+      - 속성값이 문자열이면 따옴표로 감싸줘야 한다.
+      - 숫자는 그냥 숫자를 기입해도 되지만, px 같은 건 따옴표로 감싸줘야 한다. */}
+      <h1
+        style={{
+          color: "#f00",
+          borderRight: "2px solid #000",
+          marginBottom: "50px",
+          opacity: 0.5,
+        }}
+      >
+        Hello
+      </h1>
+      <div className={styles.box}>Hello-module</div>
+      <div className="box">Hello</div>
     </div>
   );
 };

--- a/src/components/Hello.module.css
+++ b/src/components/Hello.module.css
@@ -1,0 +1,5 @@
+.box {
+  width: 200px;
+  height: 50px;
+  background-color: blue;
+}


### PR DESCRIPTION
React 에서 css 를 작성하는 3가지 방법에 대한 내용을 추가함.

**1. inline style**
    - css 파일을 따로 작성할 필요없이 html 태그에 바로 작성하는 방법

**2. css 파일 import**
    - html 태그안에 class 명을 입력하고 별도의 css 파일에 각 클래스명에 대한 스타일을 정의하고 그 css 파일을 import 해서 사용하는 방법

**3. css module**
    - module.css 파일을 styles 로 import 하고 클래스명을 문자열이 아닌 {styles.box} 객체 형태로 작성하는 방법